### PR TITLE
Closes #39 -- ApplicationStartup should draw user initialization properties from config file

### DIFF
--- a/heroku.md
+++ b/heroku.md
@@ -14,7 +14,7 @@ To configure the application to work with a heroku account of your own from a lo
 
 5.) Make a commit to your local branch
 
-6.) Set up the dev profile environment variable: `heroku config:set spring.profiles.active=dev`
+6.) Set up the heroku spring profile environment variable: `heroku config:set spring.profiles.active=heroku`
 
 7.) Push your branch to the heroku remote: `git push heroku {your-branch-name}:master`
 

--- a/src/main/java/edu/usm/config/ApplicationStartup.java
+++ b/src/main/java/edu/usm/config/ApplicationStartup.java
@@ -6,8 +6,10 @@ import edu.usm.domain.User;
 import edu.usm.domain.exception.ConstraintViolation;
 import edu.usm.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,35 +22,67 @@ import java.util.Collection;
 @Component
 public class ApplicationStartup implements ApplicationListener<ContextRefreshedEvent> {
 
-     @Autowired
+    @Autowired
     UserService userService;
 
-    private String email = "superuser@email.com";
-    private String firstName = "firstName";
-    private String lastName = "lastName";
-    private String password = "password";
+    @Autowired
+    Environment env;
+
+    @Value("${bayard.implementation.startup.email}")
+    private String superuserEmail;
+    @Value("${bayard.implementation.startup.firstName}")
+    private String superuserFirstName;
+    @Value("${bayard.implementation.startup.lastName}")
+    private String superuserLastName;
+    @Value("${bayard.implementation.startup.password}")
+    private String superuserPassword;
+
+    @Value("${bayard.dev.basicUser.email}")
+    private String devEmail;
+    @Value("${bayard.dev.basicUser.firstName}")
+    private String devFirstName;
+    @Value("${bayard.dev.basicUser.lastName}")
+    private String devLastName;
+    @Value("${bayard.dev.basicUser.password}")
+    private String devPassword;
 
     @Override
     public void onApplicationEvent(final ContextRefreshedEvent event){
         configureAuthentication();
         try {
-            createSuperuser();
-            createUser();
+            createUsers();
         } catch (ConstraintViolation e) {
             System.err.print("Error creating users on startup");
         }
         clearAuthentication();
     }
 
+    private void createUsers() throws ConstraintViolation{
+        createSuperuser();
+        for (String profile: env.getActiveProfiles()) {
+            if (profile.equals("dev")) {
+                User user = userService.findByEmail(devEmail);
+                if (user == null) {
+                    user = new User();
+                    user.setEmail(devEmail);
+                    user.setRole(Role.ROLE_USER);
+                    user.setFirstName(devFirstName);
+                    user.setLastName(devLastName);
+                    userService.createUser(user, devPassword);
+                }
+            }
+        }
+    }
+
     private void createSuperuser() throws ConstraintViolation{
-        User superUser = userService.findByEmail(email);
+        User superUser = userService.findByEmail(superuserEmail);
         if (superUser == null) {
             superUser = new User();
-            superUser.setFirstName(firstName);
-            superUser.setLastName(lastName);
-            superUser.setEmail(email);
+            superUser.setFirstName(superuserFirstName);
+            superUser.setLastName(superuserLastName);
+            superUser.setEmail(superuserEmail);
             superUser.setRole(Role.ROLE_SUPERUSER);
-            userService.createUser(superUser, password);
+            userService.createUser(superUser, superuserPassword);
        }
     }
 
@@ -66,14 +100,5 @@ public class ApplicationStartup implements ApplicationListener<ContextRefreshedE
         SecurityContextHolder.clearContext();
     }
 
-    private void createUser () throws ConstraintViolation{
-        User user = userService.findByEmail("user@email.com");
-        if (user == null) {
-            user = new User();
-            user.setEmail("user@email.com");
-            user.setRole(Role.ROLE_USER);
-            userService.createUser(user, "password");
-        }
-    }
 
 }

--- a/src/main/java/edu/usm/config/ApplicationStartup.java
+++ b/src/main/java/edu/usm/config/ApplicationStartup.java
@@ -60,7 +60,7 @@ public class ApplicationStartup implements ApplicationListener<ContextRefreshedE
     private void createUsers() throws ConstraintViolation{
         createSuperuser();
         for (String profile: env.getActiveProfiles()) {
-            if (profile.equals("dev")) {
+            if (profile.equals(BayardSpringProfiles.DEV_PROFILE)) {
                 User user = userService.findByEmail(devEmail);
                 if (user == null) {
                     user = new User();

--- a/src/main/java/edu/usm/config/BayardSpringProfiles.java
+++ b/src/main/java/edu/usm/config/BayardSpringProfiles.java
@@ -1,0 +1,14 @@
+package edu.usm.config;
+
+/**
+ * Created by andrew on 2/3/16.
+ */
+public final class BayardSpringProfiles {
+
+    public static final String DEV_PROFILE = "dev";
+    public static final String DEFAULT_PROFILE = "default";
+    public static final String PRODUCTION_PROFILE = "production";
+    public static final String HEROKU_PROFILE = "heroku";
+    public static final String TEST_PROFILE = "test";
+
+}

--- a/src/main/java/edu/usm/config/DefaultJpaConfig.java
+++ b/src/main/java/edu/usm/config/DefaultJpaConfig.java
@@ -22,7 +22,7 @@ import java.util.Properties;
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(basePackageClasses = Application.class)
-@Profile({"production", "dev","default"})
+@Profile({BayardSpringProfiles.PRODUCTION_PROFILE, BayardSpringProfiles.DEV_PROFILE, BayardSpringProfiles.DEFAULT_PROFILE})
 class DefaultJpaConfig implements TransactionManagementConfigurer {
 
     @Value("${spring.dataSource.driverClassName}")

--- a/src/main/java/edu/usm/config/DefaultJpaConfig.java
+++ b/src/main/java/edu/usm/config/DefaultJpaConfig.java
@@ -22,8 +22,8 @@ import java.util.Properties;
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(basePackageClasses = Application.class)
-@Profile({"production", "default"})
-class ProductionJpaConfig implements TransactionManagementConfigurer {
+@Profile({"production", "dev","default"})
+class DefaultJpaConfig implements TransactionManagementConfigurer {
 
     @Value("${spring.dataSource.driverClassName}")
     private String driver;

--- a/src/main/java/edu/usm/config/HerokuDevelopmentJpaConfig.java
+++ b/src/main/java/edu/usm/config/HerokuDevelopmentJpaConfig.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(basePackageClasses = Application.class)
-@Profile("heroku")
+@Profile(BayardSpringProfiles.HEROKU_PROFILE)
 class HerokuDevelopmentJpaConfig implements TransactionManagementConfigurer{
 
     @Value("${spring.dataSource.driverClassName}")

--- a/src/main/java/edu/usm/config/HerokuDevelopmentJpaConfig.java
+++ b/src/main/java/edu/usm/config/HerokuDevelopmentJpaConfig.java
@@ -27,7 +27,7 @@ import java.util.Properties;
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(basePackageClasses = Application.class)
-@Profile("dev")
+@Profile("heroku")
 class HerokuDevelopmentJpaConfig implements TransactionManagementConfigurer{
 
     @Value("${spring.dataSource.driverClassName}")

--- a/src/main/java/edu/usm/config/WebAppInitializer.java
+++ b/src/main/java/edu/usm/config/WebAppInitializer.java
@@ -1,12 +1,8 @@
 package edu.usm.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.PropertyPlaceholderConfigurer;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 import org.springframework.web.filter.DelegatingFilterProxy;
 import org.springframework.web.servlet.support.AbstractAnnotationConfigDispatcherServletInitializer;
@@ -28,7 +24,7 @@ public class WebAppInitializer extends AbstractAnnotationConfigDispatcherServlet
 
     @Override
     protected Class<?>[] getRootConfigClasses() {
-        return new Class<?>[] {ApplicationConfig.class, HerokuDevelopmentJpaConfig.class, ProductionJpaConfig.class, SecurityConfig.class};
+        return new Class<?>[] {ApplicationConfig.class, HerokuDevelopmentJpaConfig.class, DefaultJpaConfig.class, SecurityConfig.class};
     }
 
     @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,9 +7,4 @@ hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 hibernate.show_sql=true
 spring.datasource.initialize=true
 
-startup.email=superuser@email.com
-startup.password=password
-startup.firstName=Joe
-startup.lastname=Hill
-
 spring.mvc.favicon.enabled = false

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -2,3 +2,13 @@ bayard.implementation.name=Bayard
 version = ${project.version}
 bayard.implementation.largeLogoFilePath = resources/images/default-logo.png
 bayard.implementation.faviconFilePath = resources/images/default-favicon.png
+
+bayard.implementation.startup.email=superuser@email.com
+bayard.implementation.startup.password=password
+bayard.implementation.startup.firstName=Joe
+bayard.implementation.startup.lastName=Hill
+
+bayard.dev.basicUser.email=user@email.com
+bayard.dev.basicUser.password=password
+bayard.dev.basicUser.firstName=Dev
+bayard.dev.basicUser.lastName=User

--- a/src/test/java/edu/usm/config/DaoConfig.java
+++ b/src/test/java/edu/usm/config/DaoConfig.java
@@ -13,7 +13,7 @@ import javax.inject.Inject;
  */
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("test")
+@ActiveProfiles(BayardSpringProfiles.TEST_PROFILE)
 @ContextConfiguration(classes = {
         ApplicationConfig.class,
         TestJpaConfig.class,

--- a/src/test/java/edu/usm/config/EmbeddedDataSourceConfig.java
+++ b/src/test/java/edu/usm/config/EmbeddedDataSourceConfig.java
@@ -12,7 +12,7 @@ import javax.sql.DataSource;
  * The data source config that can be used in integration tests.
  */
 @Configuration
-@Profile("test")
+@Profile(BayardSpringProfiles.TEST_PROFILE)
 public class EmbeddedDataSourceConfig {
 
     @Bean

--- a/src/test/java/edu/usm/config/TestJpaConfig.java
+++ b/src/test/java/edu/usm/config/TestJpaConfig.java
@@ -25,7 +25,7 @@ import java.util.Properties;
 @Configuration
 @EnableTransactionManagement
 @EnableJpaRepositories(basePackageClasses = Application.class)
-@Profile("test")
+@Profile(BayardSpringProfiles.TEST_PROFILE)
 public class TestJpaConfig implements TransactionManagementConfigurer{
 
 

--- a/src/test/java/edu/usm/config/WebAppConfigurationAware.java
+++ b/src/test/java/edu/usm/config/WebAppConfigurationAware.java
@@ -14,7 +14,7 @@ import javax.inject.Inject;
 import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@ActiveProfiles("test")
+@ActiveProfiles(BayardSpringProfiles.TEST_PROFILE)
 @WebAppConfiguration
 @ContextConfiguration(classes = {
         ApplicationConfig.class,


### PR DESCRIPTION
On application startup, if and when users are created, their credentials are
now drawn from config.properties.

The basic user will now only be created on startup when the active Spring
profiles includes the dev profile. To take advantage of this, make sure
to set spring.profiles.active=dev in your environment/run configuration.

This pr also redefines what was previously called the dev spring
profile to what it actually is: a heroku spring profile.
