### PR TITLE
Closes #43: Use Logback as slf4j binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>9.4-1200-jdbc41</version>
+            <!--Prevents multiple slf4j bindings on the classpath-->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-simple</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <!-- Avoid: javax.validation.ValidationException: HV000183: Unable to load 'javax.el.ExpressionFactory' -->
         <dependency>
@@ -85,7 +92,7 @@
         <!-- Logging -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
+            <artifactId>jcl-over-slf4j</artifactId>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+
 <configuration scan="true" scanPeriod="3 seconds">
 	<contextName>bayard</contextName>
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>
-				%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{32} - %msg%n
-			</pattern>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
 		</encoder>
 	</appender>
 
-	<jmxConfigurator />
-	<root level="WARN">
+	<root level="INFO">
 		<appender-ref ref="STDOUT" />
 	</root>
-
-	<logger name="edu.usm" level="ALL" />
 </configuration>


### PR DESCRIPTION
Our dependency on postgresql introduced their dependency on the slf4j-simple binding to our build path. By excluding slf4j-simple from our build, our configuration of Logback is unambiguously chosen as the logger at runtime.
