### PR TITLE
Closes #79 - Flag to enable/disable Development for client and server

### DIFF
--- a/src/main/java/edu/usm/domain/ConfigDto.java
+++ b/src/main/java/edu/usm/domain/ConfigDto.java
@@ -15,6 +15,16 @@ public class ConfigDto implements Serializable{
 
     private String faviconFilePath;
 
+    private boolean developmentEnabled;
+
+    public boolean isDevelopmentEnabled() {
+        return developmentEnabled;
+    }
+
+    public void setDevelopmentEnabled(boolean developmentEnabled) {
+        this.developmentEnabled = developmentEnabled;
+    }
+
     public String getFaviconFilePath() {
         return faviconFilePath;
     }

--- a/src/main/java/edu/usm/service/impl/ConfigServiceImpl.java
+++ b/src/main/java/edu/usm/service/impl/ConfigServiceImpl.java
@@ -23,6 +23,9 @@ public class ConfigServiceImpl implements ConfigService {
     @Value("${bayard.implementation.faviconFilePath}")
     private String faviconFilePath;
 
+    @Value("${bayard.implementation.enableDevelopmentFeatures}")
+    private String developmentEnabled;
+
     @Override
     public ConfigDto getImplementationConfig() {
         ConfigDto dto = new ConfigDto();
@@ -30,6 +33,7 @@ public class ConfigServiceImpl implements ConfigService {
         dto.setVersion(version);
         dto.setLargeLogoFilePath(largeLogoFilePath);
         dto.setFaviconFilePath(faviconFilePath);
+        dto.setDevelopmentEnabled(Boolean.valueOf(developmentEnabled));
         return dto;
     }
 }

--- a/src/main/java/edu/usm/web/DonationController.java
+++ b/src/main/java/edu/usm/web/DonationController.java
@@ -6,6 +6,7 @@ import edu.usm.domain.Views;
 import edu.usm.dto.Response;
 import edu.usm.service.DonationService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping("/donations")
+@ConditionalOnExpression("${bayard.implementation.enableDevelopmentFeatures:true}")
 public class DonationController {
 
     @Autowired

--- a/src/main/java/edu/usm/web/FoundationController.java
+++ b/src/main/java/edu/usm/web/FoundationController.java
@@ -14,6 +14,7 @@ import edu.usm.dto.Response;
 import edu.usm.service.FoundationService;
 import edu.usm.service.GrantService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +26,7 @@ import java.util.Set;
  */
 @RestController
 @RequestMapping("/foundations")
+@ConditionalOnExpression("${bayard.implementation.enableDevelopmentFeatures:true}")
 public class FoundationController {
 
     @Autowired

--- a/src/main/java/edu/usm/web/GrantController.java
+++ b/src/main/java/edu/usm/web/GrantController.java
@@ -11,6 +11,7 @@ import edu.usm.dto.GrantDto;
 import edu.usm.dto.Response;
 import edu.usm.service.GrantService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +23,7 @@ import java.util.Set;
  */
 @RestController
 @RequestMapping("/grants")
+@ConditionalOnExpression("${bayard.implementation.enableDevelopmentFeatures:true}")
 public class GrantController {
 
     @Autowired

--- a/src/main/java/edu/usm/web/InteractionRecordController.java
+++ b/src/main/java/edu/usm/web/InteractionRecordController.java
@@ -9,6 +9,7 @@ import edu.usm.dto.InteractionRecordDto;
 import edu.usm.dto.Response;
 import edu.usm.service.InteractionRecordService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +21,7 @@ import java.util.Set;
  */
 @RestController
 @RequestMapping("/interactions")
+@ConditionalOnExpression("${bayard.implementation.enableDevelopmentFeatures:true}")
 public class InteractionRecordController {
 
     @Autowired

--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -2,6 +2,7 @@ bayard.implementation.name=Bayard
 version = ${project.version}
 bayard.implementation.largeLogoFilePath = resources/images/default-logo.png
 bayard.implementation.faviconFilePath = resources/images/default-favicon.ico
+bayard.implementation.enableDevelopmentFeatures=true
 
 bayard.implementation.startup.email=superuser@email.com
 bayard.implementation.startup.password=password

--- a/src/main/webapp/resources/index.html
+++ b/src/main/webapp/resources/index.html
@@ -2,7 +2,7 @@
 <html ng-app="app">
 <head lang="en">
     <meta charset="UTF-8">
-    <title>{{config.implementationName}}</title>
+    <title>{{bayardConfig.implementationName}}</title>
 
     <!--Angular Libs -->
     <script src="resources/js/libs/angular/angular.js"></script>
@@ -34,8 +34,8 @@
     <link rel="stylesheet" href="resources/css/bayard.css">
 
 
-    <link rel="icon" ng-href="{{config.faviconFilePath}}" type="image/x-icon">
-    <link rel="shortcut icon" ng-href="{{config.faviconFilePath}}" type="image/x-icon">
+    <link rel="icon" ng-href="{{bayardConfig.faviconFilePath}}" type="image/x-icon">
+    <link rel="shortcut icon" ng-href="{{bayardConfig.faviconFilePath}}" type="image/x-icon">
 </head>
 <body>
 
@@ -45,7 +45,7 @@
     <nav class="navbar navbar-inverse">
         <div>
             <div class="navbar-header">
-                <a class="navbar-brand" href="#/">{{config.implementationName}}</a>
+                <a class="navbar-brand" href="#/">{{bayardConfig.implementationName}}</a>
             </div>
 
 
@@ -63,7 +63,7 @@
                         <li><a href="#groups"><i class="fa fa-comment"></i>Groups</a></li>
                     </ul>
                 </li>
-                <li class="dropdown">
+                <li class="dropdown" ng-if="bayardConfig.developmentEnabled">
                     <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Development<span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a href="#foundations"><i class="fa fa-shield"></i>Foundations</a></li>

--- a/src/main/webapp/resources/js/app.js
+++ b/src/main/webapp/resources/js/app.js
@@ -9,10 +9,28 @@
 
     app.config(function ($routeProvider, $httpProvider) {
 
+        var resolveDevelopmentEnabled = function($q, $rootScope, ConfigService) {
+
+            if ($rootScope.bayardConfig != null) {
+                return ($rootScope.bayardConfig.developmentEnabled == true) ? $q.defer().resolve() : $q.reject("development is disabled");
+            } else {
+                ConfigService.getImplementationConfig({}, function(config) {
+                    $rootScope.bayardConfig = config;
+                    return ($rootScope.bayardConfig.developmentEnabled == true) ? $q.defer().resolve() : $q.reject("development is disabled");
+                }, function(err) {
+                    console.log(err);
+                    return ($q.reject("development is disabled"));
+                });
+            }
+        };
+
         $routeProvider
             .when('/', {
                 templateUrl: 'resources/partials/main.html',
-                controller: 'MainCtrl'
+                controller: 'MainCtrl',
+                resolve: {
+                    enabled: resolveDevelopmentEnabled
+                }
             })
             .when('/contacts', {
                 templateUrl: 'resources/partials/contactList.html',
@@ -80,33 +98,57 @@
             })
             .when('/foundations', {
                 templateUrl: 'resources/partials/foundationList.html',
-                controller: 'FoundationListCtrl'
+                controller: 'FoundationListCtrl',
+                resolve: {
+                    enabled: resolveDevelopmentEnabled
+                }
             })
             .when('/foundations/:id', {
                 templateUrl: 'resources/partials/foundationDetails.html',
-                controller: 'FoundationDetailsCtrl'
+                controller: 'FoundationDetailsCtrl',
+                resolve: {
+                    enabled: resolveDevelopmentEnabled
+                }
             })
             .when('/grants', {
                 templateUrl: 'resources/partials/grantList.html',
-                controller: 'GrantListCtrl'
+                controller: 'GrantListCtrl',
+                resolve: {
+                    enabled: resolveDevelopmentEnabled
+                }
             })
             .when('/grants/create/:foundationId', {
                 templateUrl: 'resources/partials/grantList.html',
-                controller: 'GrantListCtrl'
+                controller: 'GrantListCtrl',
+                resolve: {
+                    enabled: resolveDevelopmentEnabled
+                }
             })
             .when('/grants/:id', {
                 templateUrl: 'resources/partials/grantDetails.html',
-                controller: 'GrantDetailsCtrl'
+                controller: 'GrantDetailsCtrl',
+                resolve: {
+                    enabled: resolveDevelopmentEnabled
+                }
             })
             .when('/interactions/:id', {
                 templateUrl: 'resources/partials/interactionDetails.html',
-                controller: 'InteractionDetailsCtrl'
+                controller: 'InteractionDetailsCtrl',
+                resolve: {
+                    enabled: resolveDevelopmentEnabled
+                }
             })
             .when('/donations', {
-                templateUrl: 'resources/partials/donationList.html'
+                templateUrl: 'resources/partials/donationList.html',
+                resolve: {
+                    enabled: resolveDevelopmentEnabled
+                }
             })
             .when('/donations/:id', {
-                templateUrl: 'resources/partials/donationList.html'
+                templateUrl: 'resources/partials/donationList.html',
+                resolve: {
+                    enabled: resolveDevelopmentEnabled
+                }
             })
             .when('/logout', {
                 templateUrl: 'resources/partials/login.html',

--- a/src/main/webapp/resources/js/controllers.js
+++ b/src/main/webapp/resources/js/controllers.js
@@ -71,13 +71,6 @@
 
     controllers.controller('MainCtrl', ['$scope', '$location', 'ConfigService', function($scope, $location, ConfigService) {
 
-        ConfigService.getImplementationConfig({}, function (config) {
-            $scope.config = config;
-            console.log("Config: " + config.implementationName + ", " + config.largeLogoFilePath + ", " + config.faviconFilePath);
-        }, function (err) {
-            console.log(err);
-        });
-
     }]);
 
     controllers.controller('LogoutCtrl', ['$scope', '$location', '$rootScope', function ($scope, $location, $rootScope) {


### PR DESCRIPTION
Development features are now enabled by setting the
`bayard.implementation.enableDevelopmentFeatures` property to `true`.

If this property is set to anything other than `true`, the RestControllers
for the Development-related domain are not included in the application
context on startup, and requests to their mappings will return 404s.

The value of this property is communicated to the client along with the
other configuration options sent as a response from the ConfigController.
The client relies on a resolve function when the angular router tries to
navigate to one of the development-related URLs. If the root scope does
not yet contain the implementation config, the resolve functions fetches
the config from the server and stores it on the root scope. The resolve
function then allows or denies the route change to happen depending on
the value of the config object's `developmentEnabled` property.
