### PR TITLE
Closes #99 - Client-side deletes/edits of Donations and SustainerPeriods

### DIFF
--- a/src/main/java/edu/usm/repository/ContactDao.java
+++ b/src/main/java/edu/usm/repository/ContactDao.java
@@ -1,6 +1,7 @@
 package edu.usm.repository;
 
 import edu.usm.domain.Contact;
+import edu.usm.domain.DonorInfo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
@@ -33,5 +34,7 @@ public interface ContactDao extends CrudRepository<Contact, String> {
     Contact findOneByFirstNameAndPhoneNumber2(String firstName, String phoneNumber2);
 
     Set<Contact> findByDonorInfoCurrentSustainer(boolean status);
+
+    Contact findOneByDonorInfo(DonorInfo donorInfo);
 
 }

--- a/src/main/java/edu/usm/repository/DonorInfoDao.java
+++ b/src/main/java/edu/usm/repository/DonorInfoDao.java
@@ -7,4 +7,7 @@ import org.springframework.data.repository.CrudRepository;
  * Created by scottkimball on 2/22/15.
  */
 public interface DonorInfoDao extends CrudRepository<DonorInfo, String> {
+
+    DonorInfo findByDonations_id(String id);
+
 }

--- a/src/main/java/edu/usm/repository/EventDao.java
+++ b/src/main/java/edu/usm/repository/EventDao.java
@@ -19,4 +19,6 @@ public interface EventDao extends CrudRepository<Event,String> {
 
     HashSet<Event> findByName(String name);
 
+    Event findByDonations_id(String id);
+
 }

--- a/src/main/java/edu/usm/repository/OrganizationDao.java
+++ b/src/main/java/edu/usm/repository/OrganizationDao.java
@@ -17,4 +17,6 @@ public interface OrganizationDao extends CrudRepository<Organization, String> {
     HashSet<Organization> findAll();
 
     HashSet<Organization> findByName(String name);
+
+    Organization findByDonations_id(String id);
 }

--- a/src/main/java/edu/usm/service/ContactService.java
+++ b/src/main/java/edu/usm/service/ContactService.java
@@ -122,4 +122,7 @@ public interface ContactService {
     @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
     Set<Contact> findAllCurrentSustainers();
 
+    @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
+    Contact findContactWithDonation(Donation donation);
+
 }

--- a/src/main/java/edu/usm/service/DonationService.java
+++ b/src/main/java/edu/usm/service/DonationService.java
@@ -2,6 +2,7 @@ package edu.usm.service;
 
 import edu.usm.domain.BudgetItem;
 import edu.usm.domain.Donation;
+import edu.usm.domain.exception.ConstraintViolation;
 import edu.usm.dto.DonationDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -37,7 +38,7 @@ public interface DonationService {
     void update(Donation oldDonation, DonationDto dto);
 
     @PreAuthorize(value = "hasAnyRole('ROLE_ELEVATED','ROLE_SUPERUSER')")
-    void delete(Donation donation);
+    void delete(Donation donation) throws ConstraintViolation;
 
     @PreAuthorize(value = "hasAnyRole('ROLE_SUPERUSER')")
     void deleteAll();

--- a/src/main/java/edu/usm/service/EventService.java
+++ b/src/main/java/edu/usm/service/EventService.java
@@ -44,12 +44,15 @@ public interface EventService {
     @PreAuthorize(value = "hasAnyRole('ROLE_USER','ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
     void update(Event event, EventDto eventDto) throws ConstraintViolation, NullDomainReference.NullEvent;
 
-    @PreAuthorize(value = "hasAnyRole('ROLE_USER','ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
+    @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
     void addDonation(Event event, Donation donation) throws ConstraintViolation, NullDomainReference.NullEvent;
 
-    @PreAuthorize(value = "hasAnyRole('ROLE_USER','ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
+    @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
     void addDonation(Event event, DonationDto dto) throws ConstraintViolation, NullDomainReference.NullEvent;
 
-    @PreAuthorize(value = "hasAnyRole('ROLE_USER','ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
+    @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
     void removeDonation(Event event, Donation donation) throws ConstraintViolation, NullDomainReference.NullEvent;
+
+    @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
+    Event findEventWithDonation(Donation donation);
 }

--- a/src/main/java/edu/usm/service/OrganizationService.java
+++ b/src/main/java/edu/usm/service/OrganizationService.java
@@ -26,13 +26,16 @@ public interface OrganizationService {
     @PreAuthorize(value = "hasAnyRole('ROLE_USER','ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
     void update (Organization organization) throws NullDomainReference.NullOrganization, ConstraintViolation;
 
-    @PreAuthorize(value = "hasAnyRole('ROLE_USER','ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
+    @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
     void addDonation (Organization organization, Donation donation) throws NullDomainReference.NullOrganization, ConstraintViolation;
 
-    @PreAuthorize(value = "hasAnyRole('ROLE_USER','ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
+    @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
     void addDonation (Organization organization, DonationDto dto) throws NullDomainReference.NullOrganization, ConstraintViolation;
 
-    @PreAuthorize(value = "hasAnyRole('ROLE_USER','ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
+    @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
+    Organization findOrganizationWithDonation(Donation donation);
+
+    @PreAuthorize(value = "hasAnyRole('ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")
     void removeDonation (Organization organization, Donation donation) throws NullDomainReference.NullOrganization, ConstraintViolation;
 
     @PreAuthorize(value = "hasAnyRole('ROLE_USER','ROLE_DEVELOPMENT','ROLE_ELEVATED','ROLE_SUPERUSER')")

--- a/src/main/java/edu/usm/service/impl/ContactServiceImpl.java
+++ b/src/main/java/edu/usm/service/impl/ContactServiceImpl.java
@@ -6,6 +6,7 @@ import edu.usm.domain.exception.ConstraintViolation;
 import edu.usm.domain.exception.NullDomainReference;
 import edu.usm.dto.*;
 import edu.usm.repository.ContactDao;
+import edu.usm.repository.DonorInfoDao;
 import edu.usm.repository.SustainerPeriodDao;
 import edu.usm.service.*;
 import org.slf4j.Logger;
@@ -25,6 +26,8 @@ public class ContactServiceImpl extends DonationAssigningService implements Cont
 
     @Autowired
     private ContactDao contactDao;
+    @Autowired
+    private DonorInfoDao donorInfoDao;
     @Autowired
     private SustainerPeriodDao sustainerPeriodDao;
     @Autowired
@@ -282,6 +285,12 @@ public class ContactServiceImpl extends DonationAssigningService implements Cont
             updateLastModified(donation);
             update(contact);
         }
+    }
+
+    @Override
+    public Contact findContactWithDonation(Donation donation) {
+        DonorInfo donorInfo = donorInfoDao.findByDonations_id(donation.getId());
+        return (null == donorInfo) ? null : contactDao.findOneByDonorInfo(donorInfo);
     }
 
     @Override

--- a/src/main/java/edu/usm/service/impl/EventServiceImpl.java
+++ b/src/main/java/edu/usm/service/impl/EventServiceImpl.java
@@ -179,4 +179,9 @@ public class EventServiceImpl extends DonationAssigningService implements EventS
             update(event);
         }
     }
+
+    @Override
+    public Event findEventWithDonation(Donation donation) {
+        return eventDao.findByDonations_id(donation.getId());
+    }
 }

--- a/src/main/java/edu/usm/service/impl/OrganizationServiceImpl.java
+++ b/src/main/java/edu/usm/service/impl/OrganizationServiceImpl.java
@@ -94,6 +94,11 @@ public class OrganizationServiceImpl extends DonationAssigningService implements
     }
 
     @Override
+    public Organization findOrganizationWithDonation(Donation donation) {
+        return organizationDao.findByDonations_id(donation.getId());
+    }
+
+    @Override
     public void update(Organization organization) throws NullDomainReference.NullOrganization, ConstraintViolation{
         validateOrganization(organization);
         updateLastModified(organization);

--- a/src/main/java/edu/usm/web/DonationController.java
+++ b/src/main/java/edu/usm/web/DonationController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import edu.usm.domain.BudgetItem;
 import edu.usm.domain.Donation;
 import edu.usm.domain.Views;
+import edu.usm.domain.exception.ConstraintViolation;
 import edu.usm.domain.exception.NullDomainReference;
 import edu.usm.dto.DonationDto;
 import edu.usm.dto.Response;
@@ -61,7 +62,7 @@ public class DonationController {
 
     @RequestMapping(value= "/{id}", method = RequestMethod.DELETE, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public Response deleteDonation(@PathVariable("id")String id) {
+    public Response deleteDonation(@PathVariable("id")String id) throws ConstraintViolation{
         Donation d = donationService.findById(id);
         if (null == d) {
             //TODO: refactor 404s

--- a/src/main/webapp/resources/js/controllers.js
+++ b/src/main/webapp/resources/js/controllers.js
@@ -2479,7 +2479,7 @@
 
     }]);
 
-    controllers.controller('DonationDetailsCtrl', ['$scope', 'DonationService', '$routeParams', '$timeout', 'DateFormatter', function($scope, DonationService, $routeParams, $timeout, DateFormatter) {
+    controllers.controller('DonationDetailsCtrl', ['$scope', 'DonationService', '$routeParams', '$timeout', 'DateFormatter', '$window', function($scope, DonationService, $routeParams, $timeout, DateFormatter, $window) {
 
         $scope.modelHolder = {};
         $scope.formHolder = {};
@@ -2524,6 +2524,17 @@
             $scope.editingDonationDetails = false;
             establishDetails($scope.modelHolder.donationModel.id);
         };
+
+        $scope.deleteDonation = function() {
+            var deleteConfirmed = $window.confirm('Are you sure you want to delete this donation?');
+            if (deleteConfirmed) {
+                DonationService.delete({id: $scope.modelHolder.donationModel.id}, function (succ) {
+                    $window.history.back();
+                }, function (err) {
+                    console.log(err);
+                })
+            }
+        }
 
     }]);
 
@@ -2773,7 +2784,8 @@
         };
     }]);
 
-    controllers.controller('SustainerPeriodDetailsCtrl', ['$scope', 'ContactService', '$routeParams', '$timeout', 'DateFormatter', 'RouteChangeService', function($scope, ContactService, $routeParams, $timeout, DateFormatter, RouteChangeService) {
+    controllers.controller('SustainerPeriodDetailsCtrl', ['$scope', 'ContactService', '$routeParams', '$timeout', 'DateFormatter', 'RouteChangeService', '$window',
+        function($scope, ContactService, $routeParams, $timeout, DateFormatter, RouteChangeService, $window) {
 
         $scope.contact = RouteChangeService.get();
 
@@ -2782,7 +2794,13 @@
 
         $scope.updateSustainerPeriod = function() {
             $scope.modelHolder.sustainerPeriodModel.periodStartDate= DateFormatter.formatDate($scope.modelHolder.sustainerPeriodModel.dates.periodStartDate);
-            $scope.modelHolder.sustainerPeriodModel.cancelDate = DateFormatter.formatDate($scope.modelHolder.sustainerPeriodModel.dates.cancelDate);
+            if ($scope.modelHolder.sustainerPeriodModel.dates.cancelDate == null) {
+                $scope.modelHolder.sustainerPeriodModel.cancelDate = null;
+            } else {
+                $scope.modelHolder.sustainerPeriodModel.cancelDate = DateFormatter.formatDate($scope.modelHolder.sustainerPeriodModel.dates.cancelDate);
+            }
+
+            console.log($scope.modelHolder.sustainerPeriodModel.dates.cancelDate);
 
             ContactService.updateSustainerPeriod({id: $scope.contact.id, entityId: $scope.modelHolder.sustainerPeriodModel.id}, $scope.modelHolder.sustainerPeriodModel, function(succ) {
                 $scope.requestSuccess = true;
@@ -2803,6 +2821,9 @@
                     periodStartDate : DateFormatter.asDate(period.periodStartDate),
                     cancelDate : DateFormatter.asDate(period.cancelDate)
                 };
+                if (null == period.cancelDate) {
+                    $scope.modelHolder.sustainerPeriodModel.dates.cancelDate = null;
+                }
             }, function(err) {
                 console.log(err);
             })
@@ -2824,6 +2845,17 @@
             $scope.modelHolder.sustainerPeriodModel.dates.cancelDate = null;
             $scope.updateSustainerPeriod();
         };
+
+        $scope.deleteSustainerPeriod = function() {
+            var deleteConfirmed = $window.confirm('Are you sure you want to delete this sustainer period?');
+            if (deleteConfirmed) {
+                ContactService.deleteSustainerPeriod({id: $scope.contact.id, entityId: $scope.modelHolder.sustainerPeriodModel.id}, function (succ) {
+                    $window.history.back();
+                }, function (err) {
+                    console.log(err);
+                })
+            }
+        }
 
     }]);
 

--- a/src/main/webapp/resources/js/services.js
+++ b/src/main/webapp/resources/js/services.js
@@ -179,6 +179,10 @@
                 method: 'GET',
                 url: "/contacts/:id/sustainer/:entityId"
             },
+            deleteSustainerPeriod: {
+                method: 'DELETE',
+                url: "/contacts/:id/sustainer/:entityId"
+            },
             getAllCurrentSustainers: {
                 method: 'GET',
                 url: "/contacts/currentSustainers",

--- a/src/main/webapp/resources/partials/donationDetails.html
+++ b/src/main/webapp/resources/partials/donationDetails.html
@@ -15,6 +15,7 @@
 
                     </fieldset>
                     <button class="btn btn-primary" ng-click="editingDonationDetails = true" ng-show="!editingDonationDetails">Edit</button>
+                    <button class="btn btn-danger" ng-click="deleteDonation()" ng-show="!editingDonationDetails">Delete</button>
                     <button class="btn btn-success" ng-click="updateDonationDetails()" ng-show="editingDonationDetails" ng-disabled="formHolder.donationForm.$invalid">Submit</button>
                     <button class="btn btn-danger" ng-click="cancelUpdateDonationDetails()" ng-show="editingDonationDetails">Cancel</button>
                 </div>

--- a/src/main/webapp/resources/partials/eventDetails.html
+++ b/src/main/webapp/resources/partials/eventDetails.html
@@ -77,8 +77,10 @@
         <div ng-if="addingDonation">
             <div class="col-xs-4">
                 <div ng-include src=" 'resources/partials/forms/donationForm.html' "></div>
-                <button class="btn btn-md btn-success" ng-click="addDonationToEvent()" ng-disabled="formHolder.eventForm.$invalid">Done</button>
-                <button class="btn btn-danger" ng-click="cancelAddDonation()">Cancel</button>
+                <div class="btn-group btn-group-justified" role="group">
+                    <a href="" type="button" class="btn btn-success" ng-click="addDonationToEvent()" ng-disabled="formHolder.eventForm.$invalid">Submit</a>
+                    <a href="" type="button" class="btn btn-danger" ng-click="cancelAddDonation()">Cancel</a>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/webapp/resources/partials/forms/donationForm.html
+++ b/src/main/webapp/resources/partials/forms/donationForm.html
@@ -24,8 +24,8 @@
     <div class="row">
         <div class="form-group col-xs-12">
             <label class="control-label">Budget item:</label>
-            <select name="budgetItemId" class="form-control input-small" ng-model="modelHolder.donationModel.budgetItemId">
-                <option ng-repeat="item in budgetItems" value="{{item.id}}">{{item.name}}</option>
+            <select name="budgetItemId" class="form-control input-small" ng-model="modelHolder.donationModel.budgetItemId" ng-options="item.id as item.name for item in budgetItems">
+                <option></option>
             </select>
         </div>
     </div>

--- a/src/main/webapp/resources/partials/organizationDetails.html
+++ b/src/main/webapp/resources/partials/organizationDetails.html
@@ -84,8 +84,10 @@
         <div ng-if="addingDonation">
             <div class="col-xs-4">
                 <div ng-include src=" 'resources/partials/forms/donationForm.html' "></div>
-                <button class="btn btn-success" ng-click="addDonationToOrganization()" ng-disabled="formHolder.donationForm.$invalid">Submit</button>
-                <button class="btn btn-danger" ng-click="cancelAddDonation()">Cancel</button>
+                <div class="btn-group btn-group-justified" role="group">
+                    <a href="" type="button" class="btn btn-success" ng-click="addDonationToOrganization()" ng-disabled="formHolder.donationForm.$invalid">Submit</a>
+                    <a href="" type="button" class="btn btn-danger" ng-click="cancelAddDonation()">Cancel</a>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/webapp/resources/partials/panels/donorInfoPanel.html
+++ b/src/main/webapp/resources/partials/panels/donorInfoPanel.html
@@ -11,8 +11,10 @@
                         <div class="col-xs-6">
                             <div ng-show="donorPanel.creatingDonation">
                                 <div ng-include="'resources/partials/forms/donationForm.html'"></div>
-                                <button class="btn btn-success" ng-click="createDonation()" ng-disabled="formHolder.donationForm.$invalid">Submit</button>
-                                <button class="btn btn-danger" ng-click="cancelCreateDonation()">Cancel</button>
+                                <div class="btn-group btn-group-justified" role="group">
+                                    <a href="" type="button" class="btn btn-success" ng-click="createDonation()" ng-disabled="formHolder.donationForm.$invalid">Submit</a>
+                                    <a href="" type="button" class="btn btn-danger" ng-click="cancelCreateDonation()">Cancel</a>
+                                </div>
                             </div>
                             <button class="btn btn-success" ng-click="donorPanel.creatingDonation = true" ng-show="!donorPanel.creatingDonation">Create a Donation</button>
                             <div ng-show="!donorPanel.creatingDonation && donations.length > 0">
@@ -23,8 +25,10 @@
                         <div class="col-xs-6">
                             <div ng-show="donorPanel.creatingSustainerPeriod">
                                 <div ng-include="'resources/partials/forms/sustainerPeriodForm.html'"></div>
-                                <button class="btn btn-success" ng-click="createSustainerPeriod()" ng-disabled="formHolder.sustainerPeriodForm.$invalid">Submit</button>
-                                <button class="btn btn-danger" ng-click="cancelCreateSustainerPeriod()">Cancel</button>
+                                <div class="btn-group btn-group-justified" role="group">
+                                    <a href="" type="button" class="btn btn-success" ng-click="createSustainerPeriod()" ng-disabled="formHolder.sustainerPeriodForm.$invalid">Submit</a>
+                                    <a href="" type="button" class="btn btn-danger" ng-click="cancelCreateSustainerPeriod()">Cancel</a>
+                                </div>
                             </div>
                             <button class="btn btn-success" ng-click="donorPanel.creatingSustainerPeriod = true" ng-show="!donorPanel.creatingSustainerPeriod">Create a Sustainer Period</button>
                             <div ng-show="!donorPanel.creatingSustainerPeriod && sustainerPeriods.length > 0">

--- a/src/main/webapp/resources/partials/sustainerPeriodDetails.html
+++ b/src/main/webapp/resources/partials/sustainerPeriodDetails.html
@@ -28,13 +28,19 @@
                                 <div ng-include="'resources/partials/forms/sustainerPeriodForm.html'"></div>
 
                             </fieldset>
-                            <div class="btn-group-vertical">
-                                <button class="btn btn-primary" ng-click="editingSustainerPeriod = true" ng-show="!editingSustainerPeriod">Edit</button>
-                                <button class="btn btn-warning" ng-click="closePeriod()" ng-show="modelHolder.sustainerPeriodModel.cancelDate == null && !editingSustainerPeriod">Close</button>
-                                <button class="btn btn-warning" ng-click="openPeriod()" ng-show="modelHolder.sustainerPeriodModel.cancelDate != null && !editingSustainerPeriod">Re-open</button>
+
+                            <div class="row">
+                                <div class="col-md-10">
+                                    <div class="btn-group btn-group-justified" role="group">
+                                        <a href="" type="button" class="btn btn-primary" ng-click="editingSustainerPeriod = true" ng-show="!editingSustainerPeriod">Edit</a>
+                                        <a href="" type="button" class="btn btn-warning" ng-click="closePeriod()" ng-show="modelHolder.sustainerPeriodModel.cancelDate == null && !editingSustainerPeriod">Close</a>
+                                        <a href="" type="button" class="btn btn-warning" ng-click="openPeriod()" ng-show="modelHolder.sustainerPeriodModel.cancelDate != null && !editingSustainerPeriod">Re-open</a>
+                                        <a href="" type="button" class="btn btn-danger" ng-click="deleteSustainerPeriod()" ng-show="!editingSustainerPeriod">Delete</a>
+                                        <a href="" type="button" class="btn btn-success" ng-click="updateSustainerPeriod()" ng-show="editingSustainerPeriod" ng-disabled="formHolder.sustainerPeriodForm.$invalid">Submit</a>
+                                        <a href="" type="button" class="btn btn-danger" ng-click="cancelUpdateSustainerPeriod()" ng-show="editingSustainerPeriod">Cancel</a>
+                                    </div>
+                                </div>
                             </div>
-                            <button class="btn btn-success" ng-click="updateSustainerPeriod()" ng-show="editingSustainerPeriod" ng-disabled="formHolder.sustainerPeriodForm.$invalid">Submit</button>
-                            <button class="btn btn-danger" ng-click="cancelUpdateSustainerPeriod()" ng-show="editingSustainerPeriod">Cancel</button>
                         </div>
                     </div>
                 </div>

--- a/src/test/java/edu/usm/it/service/ContactServiceTest.java
+++ b/src/test/java/edu/usm/it/service/ContactServiceTest.java
@@ -547,6 +547,18 @@ public class ContactServiceTest extends WebAppConfigurationAware {
     }
 
     @Test
+    public void testFindContactWithDonation() throws Exception {
+        contactService.create(contact);
+        contactService.addDonation(contact, donation);
+
+        contact = contactService.findById(contact.getId());
+        donation = contact.getDonorInfo().getDonations().iterator().next();
+        Contact withDonation = contactService.findContactWithDonation(donation);
+        assertEquals(contact, withDonation);
+
+    }
+
+    @Test
     public void testCreateSustainerPeriod() throws Exception {
         contactService.create(contact);
         contactService.createSustainerPeriod(contact, sustainerPeriod);
@@ -599,6 +611,8 @@ public class ContactServiceTest extends WebAppConfigurationAware {
         assertTrue(sustainers.contains(contact2));
         assertFalse(sustainers.contains(contact));
     }
+
+
 
 
 

--- a/src/test/java/edu/usm/it/service/DonationServiceTest.java
+++ b/src/test/java/edu/usm/it/service/DonationServiceTest.java
@@ -96,7 +96,7 @@ public class DonationServiceTest extends WebAppConfigurationAware {
     }
 
     @Test
-    public void testDeleteDonation() {
+    public void testDeleteDonation() throws Exception{
         donationService.create(donation);
         donation = donationService.findById(donation.getId());
 
@@ -122,17 +122,13 @@ public class DonationServiceTest extends WebAppConfigurationAware {
         assertTrue(contact.getDonorInfo().getDonations().contains(donation));
         assertTrue(organization.getDonations().contains(donation));
 
-        contactService.removeDonation(contact, donation);
+        donationService.delete(donation);
+        donation = donationService.findById(donation.getId());
+        assertNull(donation);
         contact = contactService.findById(contact.getId());
         organization = organizationService.findById(organization.getId());
-        assertFalse(contact.getDonorInfo().getDonations().contains(donation));
-        assertTrue(organization.getDonations().contains(donation));
-
-        organizationService.removeDonation(organization, donation);
-        organization = organizationService.findById(organization.getId());
-        donation = donationService.findById(donation.getId());
-        assertNotNull(donation);
-        assertFalse(organization.getDonations().contains(donation));
+        assertTrue(organization.getDonations().isEmpty());
+        assertTrue(contact.getDonorInfo().getDonations().isEmpty());
     }
 
     @Test

--- a/src/test/java/edu/usm/it/service/EventServiceTest.java
+++ b/src/test/java/edu/usm/it/service/EventServiceTest.java
@@ -10,7 +10,6 @@ import edu.usm.dto.EventDto;
 import edu.usm.service.CommitteeService;
 import edu.usm.service.DonationService;
 import edu.usm.service.EventService;
-import junit.framework.Assert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -187,6 +186,18 @@ public class EventServiceTest extends WebAppConfigurationAware {
 
         donation = donationService.findById(donation.getId());
         assertNotNull(donation);
+    }
+
+    @Test
+    public void testFindEventWithDonation() throws Exception {
+        eventService.create(event);
+        eventService.addDonation(event, donation);
+
+        event = eventService.findById(event.getId());
+        donation = event.getDonations().iterator().next();
+
+        Event withDonation = eventService.findEventWithDonation(donation);
+        assertEquals(event, withDonation);
     }
 
     private Event generateDuplicate(Event event) {

--- a/src/test/java/edu/usm/it/service/OrganizationServiceTest.java
+++ b/src/test/java/edu/usm/it/service/OrganizationServiceTest.java
@@ -168,4 +168,16 @@ public class OrganizationServiceTest extends WebAppConfigurationAware {
         organization = organizationService.findById(organization.getId());
         assertTrue(organization.getDonations().isEmpty());
     }
+
+    @Test
+    public void findOrganizationWithDonation() throws Exception {
+        organizationService.create(organization);
+        organizationService.addDonation(organization, donation);
+
+        organization = organizationService.findById(organization.getId());
+        donation = organization.getDonations().iterator().next();
+
+        Organization withDonation = organizationService.findOrganizationWithDonation(donation);
+        assertEquals(organization, withDonation);
+    }
 }


### PR DESCRIPTION
Users now have a way to edit and delete existing donations and sustainer
periods by navigating to their respective details pages.
